### PR TITLE
Config for metadata fields

### DIFF
--- a/sdg/MetadataReportService.py
+++ b/sdg/MetadataReportService.py
@@ -1,11 +1,6 @@
-import os
-import sdg
 import pandas as pd
 from slugify import slugify
 from sdg.Loggable import Loggable
-import urllib.request
-import json
-import numpy as np
 
 class MetadataReportService(Loggable):
     """Report generation to document metadata_fields in data."""
@@ -355,7 +350,3 @@ class MetadataReportService(Loggable):
         link = '<a href="{href}">{label}</a>'
         href = self.indicator_url.replace('[id]', indicator_id)
         return link.format(href=href, label=indicator_label)
-
-
-    def remove_links_from_dataframe(self, df):
-        return df.replace('<[^<]+?>', '', regex=True)

--- a/sdg/MetadataReportService.py
+++ b/sdg/MetadataReportService.py
@@ -93,6 +93,7 @@ class MetadataReportService(Loggable):
                         "instances": 0,
                         "name": value,
                         "label": value,
+                        "field_label": label,
                 }
 
                 all_fields[field]["values"][value]["instances"] +=1

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -549,6 +549,7 @@ class OutputDocumentationService(Loggable):
         service = self.metadata_report_service
         metadata_field = info['name']
         filename = info['filename']
+        label = info['label']
 
         values_df = service.get_metadata_field_dataframe(info)
         values_download_label = 'Download CSV of values used in this metadata field'
@@ -562,7 +563,7 @@ class OutputDocumentationService(Loggable):
         indicators_download = self.get_csv_download(indicators_df, indicators_download_file, label=indicators_download_label)
         indicators_table = self.html_from_dataframe(indicators_df, table_id='indicators-table')
 
-        detail_html = self.get_html('Metadata field ' + metadata_field, service.get_metadata_field_detail_template().format(
+        detail_html = self.get_html('Metadata field: ' + label, service.get_metadata_field_detail_template().format(
             values_download=values_download,
             values_table=values_table,
             indicators_download=indicators_download,
@@ -574,6 +575,7 @@ class OutputDocumentationService(Loggable):
         service = self.metadata_report_service
         metadata_field = str(info['field'])
         metadata_field_value = str(info['name'])
+        field_label = info['field_label']
         filename = info['filename']
 
         df = service.get_metadata_field_value_dataframe(info)
@@ -582,7 +584,7 @@ class OutputDocumentationService(Loggable):
         download = self.get_csv_download(df, download_file, label=download_label)
         table = self.html_from_dataframe(df, table_id='metadata-field-value-table')
 
-        html = self.get_html(metadata_field + ': ' + metadata_field_value, service.get_metadata_field_value_detail_template().format(
+        html = self.get_html(field_label + ': ' + metadata_field_value, service.get_metadata_field_value_detail_template().format(
             download=download,
             table=table
         ))

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -231,17 +231,20 @@ class OutputDocumentationService(Loggable):
         card_number += 1
         if card_number % 3 == 0:
             html += row_end
-        if card_number % 3 == 0:
-            html += row_start
-        html += self.get_index_card_template().format(
-            title='Metadata report',
-            description='These tables show information about the indicators.',
-            destination='metadata.html',
-            call_to_action='See metadata report'
-        )
-        card_number += 1
-        if card_number % 3 != 0:
-            html += row_end
+
+        # Add the metadata report.
+        if self.metadata_report_service is not None and self.metadata_report_service.validate_field_config():
+            if card_number % 3 == 0:
+                html += row_start
+            html += self.get_index_card_template().format(
+                title='Metadata report',
+                description='These tables show information about the indicators.',
+                destination='metadata.html',
+                call_to_action='See metadata report'
+            )
+            card_number += 1
+            if card_number % 3 != 0:
+                html += row_end
 
         page_html = self.get_html('Overview', html)
         self.write_page('index.html', page_html)
@@ -512,10 +515,7 @@ class OutputDocumentationService(Loggable):
     def write_metadata_report(self):
         service = self.metadata_report_service
 
-        if service is None:
-            return
-
-        if not service.validate_field_config():
+        if service is None or not service.validate_field_config():
             return
 
         store = self.metadata_report_service.get_metadata_field_store()

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -82,7 +82,7 @@ class OutputDocumentationService(Loggable):
             extra_disaggregations = extra_disaggregations,
         )
         self.metadata_report_service = None
-        if len(metadata_fields) > 0:
+        if metadata_fields is not None and len(metadata_fields) > 0:
             self.metadata_report_service = sdg.MetadataReportService(
                 self.outputs,
                 languages = self.languages if translate_metadata else [],

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -46,7 +46,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
                    docs_subfolder=None, indicator_downloads=None, docs_baseurl='',
                    docs_extra_disaggregations=None, docs_translate_disaggregations=False,
                    logging=None, indicator_export_filename='all_indicators',
-                   datapackage=None, csvw=None, data_schema=None):
+                   datapackage=None, csvw=None, data_schema=None, docs_metadata_fields=None):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -83,6 +83,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         data_schema: Dict describing an instance of DataSchemaInputBase subclass
         logging : list or None. The types of logs to print, including 'warn' and 'debug'.
         indicator_export_filename: string. Filename without extension for zip file
+        docs_metadata_fields: list. List of dicts describing metadata fields for
+            the MetadataReportService class.
 
     Returns:
         Boolean status of file writes
@@ -97,6 +99,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         indicator_options = open_sdg_indicator_options_defaults()
     if logging is None:
         logging = ['warn']
+    if docs_metadata_fields is None:
+        docs_metadata_fields = []
 
     status = True
 
@@ -125,6 +129,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         'data_schema': data_schema,
         'logging': logging,
         'indicator_export_filename': indicator_export_filename,
+        'docs_metadata_fields': docs_metadata_fields,
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)
@@ -169,6 +174,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         extra_disaggregations=options['docs_extra_disaggregations'],
         translate_disaggregations=options['docs_translate_disaggregations'],
         logging=logging,
+        metadata_fields=options['docs_metadata_fields'],
     )
     documentation_service.generate_documentation()
 


### PR DESCRIPTION
@Govej Here are some tweaks to allow for configurable metadata fields. The idea with this is that the configuration (in the config_data.yml file) would be something like this:

```
docs_metadata_fields:
    - key: reporting_status
      label: Reporting status
    - key: data_show_map
      label: Show map
```

If that config is not present, the report will not be generated.

A few other notes:
* I removed the "standalone" part because I don't think it's necessary, standalone indicators should be filtered out during the "get_all_indicators" method.
* The value filenames should include the metadata field, which should avoid the "True" problem
* I removed a few bits of code that I don't think are being used